### PR TITLE
feat: 自动生成build-profile.json5

### DIFF
--- a/tester/harmony/build-profile.template.json5
+++ b/tester/harmony/build-profile.template.json5
@@ -1,0 +1,44 @@
+{
+  app: {
+    products: [
+      {
+        name: 'default',
+        signingConfig: 'default',
+        compileSdkVersion: '5.0.0(12)',
+        compatibleSdkVersion: '5.0.0(12)',
+        runtimeOS: 'HarmonyOS'
+      },
+    ],
+    buildModeSet: [
+      {
+        name: 'debug',
+      },
+      {
+        name: 'release',
+      },
+    ],
+    "signingConfigs": []
+  },
+  modules: [
+    {
+      name: 'entry',
+      srcPath: './entry',
+      targets: [
+        {
+          name: 'default',
+          applyToProducts: [
+            'default'
+          ],
+        },
+      ],
+    },
+    {
+      "name": "no_codegen_sample_package",
+      "srcPath": "./no_codegen_sample_package",
+    },
+    {
+      "name": "codegen_sample_package",
+      "srcPath": "./codegen_sample_package",
+    }
+  ],
+}

--- a/tester/package.json
+++ b/tester/package.json
@@ -6,7 +6,8 @@
     "i": "npm install",
     "start": "npm run codegen && hdc rport tcp:8081 tcp:8081 && react-native start",
     "codegen": "react-native codegen-harmony --rnoh-module-path ./harmony/entry/oh_modules/@rnoh/react-native-openharmony",
-    "dev": "npm run codegen && react-native bundle-harmony --dev --minify=false"
+    "dev": "npm run codegen && react-native bundle-harmony --dev --minify=false",
+    "postinstall": "node ./scripts/create-build-profile"
   },
   "dependencies": {
     "@gorhom/portal": "^1.0.14",

--- a/tester/scripts/create-build-profile.js
+++ b/tester/scripts/create-build-profile.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const JSON5 = require('json5');
+const path = require('path');
+
+const templatePath = path.join(
+  __dirname,
+  '..',
+  'harmony',
+  'build-profile.template.json5',
+);
+const existingProfilePath = path.join(
+  __dirname,
+  '..',
+  'harmony',
+  'build-profile.json5',
+);
+
+if (fs.existsSync(existingProfilePath)) {
+  let existingProfile = JSON5.parse(
+    fs.readFileSync(existingProfilePath, 'utf-8'),
+  );
+  let template = JSON5.parse(fs.readFileSync(templatePath, 'utf-8'));
+  let signingConfigs =
+    existingProfile.app && existingProfile.app.signingConfigs;
+
+  existingProfile = {...template};
+
+  if (signingConfigs) {
+    existingProfile.app.signingConfigs = signingConfigs;
+  }
+
+  fs.writeFileSync(
+    existingProfilePath,
+    JSON5.stringify(existingProfile, null, 2),
+  );
+} else {
+  // File doesn't exist, create a copy from the template
+  fs.copyFileSync(templatePath, existingProfilePath);
+}


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- 这个 PR 解决了哪些 issues
  - closes #8 
- 这个功能是什么
  - 自动生成build-profile.json5，以防止签名信息提交到代码仓
- 您是如何实现解决方案的
  - 在RN工程中添加 postinstall 脚本
- 这个更改影响了库的哪些部分
  - npm install流程

## Test Plan
测试步骤：
1. 查看 tester/harmony/ 下是否有 build-profile.json5、build-profile.template.json5 文件
2. 在 RN 工程执行 npm install 
3. 再次查看 tester/harmony/ 下是否有 build-profile.json5

预期结果：
1. tester/harmony/ 下存在 build-profile.template.json5 文件
2. npm install 正常执行未报错
3. tester/harmony/ 下生成 build-profile.json5 文件

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在设备和模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

